### PR TITLE
feat: add CI/CD workflows, README, and LICENSE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v -race -coverprofile=coverage.out ./...
+
+      - name: Run vet
+        run: go vet ./...
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          go build -ldflags="-s -w" -o bb-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/bb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,3 +66,18 @@ release:
   prerelease: auto
   mode: replace
   name_template: "v{{.Version}}"
+
+brews:
+  - name: bb
+    repository:
+      owner: rbansal42
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    folder: Formula
+    homepage: "https://github.com/rbansal42/bb"
+    description: "Unofficial CLI for Bitbucket Cloud"
+    license: "MIT"
+    install: |
+      bin.install "bb"
+    test: |
+      system "#{bin}/bb", "version"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Rahul Bansal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,138 @@
+# bb - Bitbucket CLI
+
+An unofficial command-line interface for Bitbucket Cloud, inspired by GitHub's `gh` CLI.
+
+## Installation
+
+### Homebrew (macOS and Linux)
+
+```bash
+brew install rbansal42/tap/bb
+```
+
+### Download Binary
+
+Download the latest release from the [releases page](https://github.com/rbansal42/bb/releases).
+
+### Build from Source
+
+```bash
+go install github.com/rbansal42/bb/cmd/bb@latest
+```
+
+## Quick Start
+
+1. **Authenticate with Bitbucket:**
+   ```bash
+   bb auth login
+   ```
+
+2. **Start using commands:**
+   ```bash
+   bb pr list
+   bb repo clone workspace/repo
+   bb issue create
+   ```
+
+## Commands
+
+### Authentication
+- `bb auth login` - Authenticate with Bitbucket
+- `bb auth logout` - Log out of Bitbucket
+- `bb auth status` - View authentication status
+
+### Pull Requests
+- `bb pr list` - List pull requests
+- `bb pr view <number>` - View a pull request
+- `bb pr create` - Create a pull request
+- `bb pr merge <number>` - Merge a pull request
+- `bb pr checkout <number>` - Checkout a pull request
+- `bb pr close <number>` - Close a pull request
+- `bb pr approve <number>` - Approve a pull request
+- `bb pr diff <number>` - View pull request diff
+
+### Repositories
+- `bb repo list` - List repositories
+- `bb repo view` - View repository details
+- `bb repo clone <repo>` - Clone a repository
+- `bb repo create` - Create a repository
+- `bb repo fork <repo>` - Fork a repository
+
+### Issues
+- `bb issue list` - List issues
+- `bb issue view <number>` - View an issue
+- `bb issue create` - Create an issue
+- `bb issue close <number>` - Close an issue
+- `bb issue comment <number>` - Comment on an issue
+
+### Pipelines
+- `bb pipeline list` - List pipelines
+- `bb pipeline view <uuid>` - View pipeline details
+- `bb pipeline run` - Trigger a pipeline
+- `bb pipeline logs <uuid>` - View pipeline logs
+- `bb pipeline stop <uuid>` - Stop a running pipeline
+
+### Branches
+- `bb branch list` - List branches
+- `bb branch create <name>` - Create a branch
+- `bb branch delete <name>` - Delete a branch
+
+### Workspaces
+- `bb workspace list` - List workspaces
+- `bb workspace view <slug>` - View workspace details
+- `bb workspace members <slug>` - List workspace members
+
+### Projects
+- `bb project list` - List projects
+- `bb project view <key>` - View project details
+- `bb project create` - Create a project
+
+### Snippets
+- `bb snippet list` - List snippets
+- `bb snippet view <id>` - View a snippet
+- `bb snippet create` - Create a snippet
+- `bb snippet edit <id>` - Edit a snippet
+- `bb snippet delete <id>` - Delete a snippet
+
+### Other
+- `bb browse` - Open repository in browser
+- `bb api <endpoint>` - Make API requests
+- `bb config` - Manage configuration
+- `bb completion` - Generate shell completions
+
+## Shell Completion
+
+Generate completions for your shell:
+
+```bash
+# Bash
+bb completion bash > /etc/bash_completion.d/bb
+
+# Zsh
+bb completion zsh > "${fpath[1]}/_bb"
+
+# Fish
+bb completion fish > ~/.config/fish/completions/bb.fish
+
+# PowerShell
+bb completion powershell | Out-String | Invoke-Expression
+```
+
+## Configuration
+
+Configuration is stored in `~/.config/bb/` (or `$XDG_CONFIG_HOME/bb/`).
+
+- `hosts.yml` - Authentication tokens and host configuration
+- `config.yml` - General settings
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+MIT License - see [LICENSE](LICENSE) for details.
+
+## Disclaimer
+
+This is an unofficial CLI tool and is not affiliated with or endorsed by Atlassian or Bitbucket.

--- a/docs/plans/2026-02-05-phase-5d-distribution.md
+++ b/docs/plans/2026-02-05-phase-5d-distribution.md
@@ -1,0 +1,88 @@
+# Phase 5d: Distribution & Releases Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Set up automated releases and distribution for the bb CLI.
+
+**Architecture:** Use GoReleaser for building and releasing, GitHub Actions for CI/CD, and Homebrew tap for macOS/Linux distribution.
+
+**Tech Stack:** GoReleaser v2, GitHub Actions, Homebrew
+
+---
+
+## Completed Tasks
+
+### Task 1: CI Workflow
+**Files:** `.github/workflows/ci.yml`
+
+Created GitHub Actions workflow for:
+- Running tests on push to main/dev and PRs
+- Running go vet
+- Building for all platforms (linux, darwin, windows) x (amd64, arm64)
+
+### Task 2: Release Workflow
+**Files:** `.github/workflows/release.yml`
+
+Created GitHub Actions workflow for:
+- Triggering on version tags (v*)
+- Running tests
+- Running GoReleaser to build and publish releases
+
+### Task 3: GoReleaser Configuration
+**Files:** `.goreleaser.yml`
+
+Updated existing config to include:
+- Homebrew tap support
+- All existing build configurations preserved
+
+### Task 4: License File
+**Files:** `LICENSE`
+
+Added MIT license.
+
+### Task 5: README
+**Files:** `README.md`
+
+Created comprehensive README with:
+- Installation instructions (Homebrew, binary download, source)
+- Quick start guide
+- Full command reference
+- Shell completion instructions
+- Configuration info
+- Contributing guide
+
+---
+
+## Manual Setup Required
+
+### Homebrew Tap Repository
+
+To enable Homebrew installation, create a new repository:
+1. Create `rbansal42/homebrew-tap` on GitHub
+2. Add `HOMEBREW_TAP_GITHUB_TOKEN` secret to bb repository with write access to the tap repo
+
+### Creating a Release
+
+```bash
+# Tag the release
+git tag v0.1.0
+git push origin v0.1.0
+
+# The release workflow will automatically:
+# 1. Run tests
+# 2. Build binaries for all platforms
+# 3. Create GitHub release with binaries
+# 4. Update Homebrew formula (if tap repo exists)
+```
+
+---
+
+## Summary
+
+| Task | Files | Status |
+|------|-------|--------|
+| CI Workflow | .github/workflows/ci.yml | Done |
+| Release Workflow | .github/workflows/release.yml | Done |
+| GoReleaser Config | .goreleaser.yml | Updated |
+| LICENSE | LICENSE | Done |
+| README | README.md | Done |


### PR DESCRIPTION
## Summary

Sets up distribution and release infrastructure (#11).

### Changes

**CI Workflow** (`.github/workflows/ci.yml`)
- Runs on push to main/dev and PRs
- Tests with race detector and coverage
- Builds for all platforms (linux, darwin, windows) x (amd64, arm64)

**Release Workflow** (`.github/workflows/release.yml`)
- Triggers on version tags (v*)
- Runs tests then GoReleaser
- Creates GitHub release with binaries

**GoReleaser Config** (`.goreleaser.yml`)
- Added Homebrew tap support
- Will publish to `rbansal42/homebrew-tap` when configured

**README.md**
- Installation instructions (Homebrew, binary, source)
- Quick start guide
- Full command reference
- Shell completion docs

**LICENSE**
- MIT License

### Release Process

```bash
git tag v0.1.0
git push origin v0.1.0
# GitHub Actions will build and release
```

### Manual Setup Required

For Homebrew to work:
1. Create `rbansal42/homebrew-tap` repository
2. Add `HOMEBREW_TAP_GITHUB_TOKEN` secret with write access

Closes #11