### PR TITLE
feat: add pr reopen, edit, and checks commands

### DIFF
--- a/internal/api/pullrequests.go
+++ b/internal/api/pullrequests.go
@@ -291,6 +291,22 @@ func (c *Client) DeclinePullRequest(ctx context.Context, workspace, repoSlug str
 	return ParseResponse[*PullRequest](resp)
 }
 
+// ReopenPullRequest reopens a declined pull request
+func (c *Client) ReopenPullRequest(ctx context.Context, workspace, repoSlug string, prID int64) (*PullRequest, error) {
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d", workspace, repoSlug, prID)
+
+	body := map[string]interface{}{
+		"state": "OPEN",
+	}
+
+	resp, err := c.Put(ctx, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseResponse[*PullRequest](resp)
+}
+
 // ApprovePullRequest approves a pull request
 func (c *Client) ApprovePullRequest(ctx context.Context, workspace, repoSlug string, prID int64) (*Participant, error) {
 	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d/approve", workspace, repoSlug, prID)

--- a/internal/cmd/pr/checks.go
+++ b/internal/cmd/pr/checks.go
@@ -1,0 +1,176 @@
+package pr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rbansal42/bb/internal/api"
+	"github.com/rbansal42/bb/internal/iostreams"
+)
+
+// ChecksOptions holds the options for the checks command
+type ChecksOptions struct {
+	Repo    string
+	PRID    int64
+	JSON    bool
+	Streams *iostreams.IOStreams
+}
+
+// NewCmdChecks creates the pr checks command
+func NewCmdChecks(streams *iostreams.IOStreams) *cobra.Command {
+	opts := &ChecksOptions{Streams: streams}
+
+	cmd := &cobra.Command{
+		Use:   "checks <number>",
+		Short: "View status checks for a pull request",
+		Long: `View the status of CI/CD checks for a pull request.
+
+Shows build statuses, pipeline results, and other commit statuses
+associated with the pull request.`,
+		Example: `  # View checks for PR #123
+  bb pr checks 123
+
+  # View checks with JSON output
+  bb pr checks 123 --json
+
+  # View checks for a specific repository
+  bb pr checks 123 --repo workspace/repo`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid pull request number: %s", args[0])
+			}
+			if id <= 0 {
+				return fmt.Errorf("invalid pull request number: must be a positive integer")
+			}
+			opts.PRID = id
+			return runChecks(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in WORKSPACE/REPO format")
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output in JSON format")
+
+	return cmd
+}
+
+func runChecks(ctx context.Context, opts *ChecksOptions) error {
+	// Parse repository
+	workspace, repoSlug, err := parseRepository(opts.Repo)
+	if err != nil {
+		return err
+	}
+
+	// Get API client
+	client, err := getAPIClient()
+	if err != nil {
+		return err
+	}
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Get statuses
+	result, err := client.GetPullRequestStatuses(ctx, workspace, repoSlug, opts.PRID)
+	if err != nil {
+		return fmt.Errorf("failed to get status checks: %w", err)
+	}
+
+	if len(result.Values) == 0 {
+		opts.Streams.Info("No status checks found for PR #%d", opts.PRID)
+		return nil
+	}
+
+	// Output
+	if opts.JSON {
+		return outputChecksJSON(opts.Streams, result.Values)
+	}
+
+	return outputChecksTable(opts.Streams, result.Values)
+}
+
+func outputChecksJSON(streams *iostreams.IOStreams, statuses []api.CommitStatus) error {
+	output := make([]map[string]interface{}, len(statuses))
+	for i, s := range statuses {
+		output[i] = map[string]interface{}{
+			"name":        s.Name,
+			"key":         s.Key,
+			"state":       s.State,
+			"description": s.Description,
+			"url":         s.URL,
+			"created_on":  s.CreatedOn,
+			"updated_on":  s.UpdatedOn,
+		}
+	}
+
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+
+	fmt.Fprintln(streams.Out, string(data))
+	return nil
+}
+
+func outputChecksTable(streams *iostreams.IOStreams, statuses []api.CommitStatus) error {
+	w := tabwriter.NewWriter(streams.Out, 0, 0, 2, ' ', 0)
+
+	// Header
+	header := "STATUS\tNAME\tDESCRIPTION"
+	if streams.ColorEnabled() {
+		fmt.Fprintln(w, iostreams.Bold+header+iostreams.Reset)
+	} else {
+		fmt.Fprintln(w, header)
+	}
+
+	// Rows
+	for _, s := range statuses {
+		status := formatCheckStatus(s.State, streams.ColorEnabled())
+		name := s.Name
+		if name == "" {
+			name = s.Key
+		}
+		desc := truncateString(s.Description, 50)
+
+		fmt.Fprintf(w, "%s\t%s\t%s\n", status, name, desc)
+	}
+
+	return w.Flush()
+}
+
+// formatCheckStatus formats the check status with optional color
+func formatCheckStatus(state string, color bool) string {
+	// States: SUCCESSFUL, FAILED, INPROGRESS, STOPPED
+	switch state {
+	case "SUCCESSFUL":
+		if color {
+			return iostreams.Green + "✓ pass" + iostreams.Reset
+		}
+		return "✓ pass"
+	case "FAILED":
+		if color {
+			return iostreams.Red + "✗ fail" + iostreams.Reset
+		}
+		return "✗ fail"
+	case "INPROGRESS":
+		if color {
+			return iostreams.Yellow + "○ running" + iostreams.Reset
+		}
+		return "○ running"
+	case "STOPPED":
+		if color {
+			return iostreams.White + "◌ stopped" + iostreams.Reset
+		}
+		return "◌ stopped"
+	default:
+		return state
+	}
+}

--- a/internal/cmd/pr/edit.go
+++ b/internal/cmd/pr/edit.go
@@ -1,0 +1,126 @@
+package pr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rbansal42/bb/internal/api"
+	"github.com/rbansal42/bb/internal/iostreams"
+)
+
+type editOptions struct {
+	streams *iostreams.IOStreams
+	repo    string
+	prID    int64
+	title   string
+	body    string
+	base    string // destination branch
+	jsonOut bool
+}
+
+// NewCmdEdit creates the edit command
+func NewCmdEdit(streams *iostreams.IOStreams) *cobra.Command {
+	opts := &editOptions{
+		streams: streams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit <number>",
+		Short: "Edit a pull request",
+		Long: `Edit the title, description, or destination branch of a pull request.
+
+At least one of --title, --body, or --base must be specified.`,
+		Example: `  # Edit PR title
+  bb pr edit 123 --title "New title"
+
+  # Edit PR description
+  bb pr edit 123 --body "New description"
+
+  # Edit destination branch
+  bb pr edit 123 --base develop
+
+  # Edit multiple fields
+  bb pr edit 123 --title "New title" --body "New description"
+
+  # Output as JSON
+  bb pr edit 123 --title "New title" --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid pull request number: %s", args[0])
+			}
+			opts.prID = id
+			return runEdit(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.repo, "repo", "R", "", "Repository in WORKSPACE/REPO format")
+	cmd.Flags().StringVarP(&opts.title, "title", "t", "", "New title for the pull request")
+	cmd.Flags().StringVarP(&opts.body, "body", "b", "", "New description for the pull request")
+	cmd.Flags().StringVar(&opts.base, "base", "", "New destination branch")
+	cmd.Flags().BoolVar(&opts.jsonOut, "json", false, "Output in JSON format")
+
+	return cmd
+}
+
+func runEdit(ctx context.Context, opts *editOptions) error {
+	// Validate - at least one field must be specified
+	if opts.title == "" && opts.body == "" && opts.base == "" {
+		return fmt.Errorf("nothing to edit: specify --title, --body, or --base")
+	}
+
+	// Parse repository
+	workspace, repoSlug, err := parseRepository(opts.repo)
+	if err != nil {
+		return err
+	}
+
+	// Get API client
+	client, err := getAPIClient()
+	if err != nil {
+		return err
+	}
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Build update options
+	updateOpts := &api.PRCreateOptions{
+		Title:             opts.title,
+		Description:       opts.body,
+		DestinationBranch: opts.base,
+	}
+
+	// Update PR
+	pr, err := client.UpdatePullRequest(ctx, workspace, repoSlug, opts.prID, updateOpts)
+	if err != nil {
+		return fmt.Errorf("failed to update pull request: %w", err)
+	}
+
+	// Handle --json flag
+	if opts.jsonOut {
+		return outputEditJSON(opts.streams, pr)
+	}
+
+	// Output success message
+	opts.streams.Success("Edited pull request #%d", opts.prID)
+	fmt.Fprintln(opts.streams.Out, pr.Links.HTML.Href)
+
+	return nil
+}
+
+func outputEditJSON(streams *iostreams.IOStreams, pr *api.PullRequest) error {
+	data, err := json.MarshalIndent(api.PullRequestJSON{PullRequest: pr}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	fmt.Fprintln(streams.Out, string(data))
+	return nil
+}

--- a/internal/cmd/pr/pr.go
+++ b/internal/cmd/pr/pr.go
@@ -31,12 +31,15 @@ your changes are merged.`,
 	cmd.AddCommand(NewCmdList(streams))
 	cmd.AddCommand(NewCmdView(streams))
 	cmd.AddCommand(NewCmdCreate(streams))
+	cmd.AddCommand(NewCmdEdit(streams))
 	cmd.AddCommand(NewCmdCheckout(streams))
 	cmd.AddCommand(NewCmdMerge(streams))
 	cmd.AddCommand(NewCmdClose(streams))
+	cmd.AddCommand(NewCmdReopen(streams))
 	cmd.AddCommand(NewCmdReview(streams))
 	cmd.AddCommand(NewCmdDiff(streams))
 	cmd.AddCommand(NewCmdComment(streams))
+	cmd.AddCommand(NewCmdChecks(streams))
 
 	return cmd
 }

--- a/internal/cmd/pr/reopen.go
+++ b/internal/cmd/pr/reopen.go
@@ -1,0 +1,84 @@
+package pr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rbansal42/bb/internal/iostreams"
+)
+
+type reopenOptions struct {
+	streams *iostreams.IOStreams
+	repo    string
+}
+
+// NewCmdReopen creates the reopen command
+func NewCmdReopen(streams *iostreams.IOStreams) *cobra.Command {
+	opts := &reopenOptions{
+		streams: streams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "reopen <number>",
+		Short: "Reopen a declined pull request",
+		Long: `Reopen a pull request that was previously declined.
+
+Only declined pull requests can be reopened. Merged pull requests cannot be reopened.`,
+		Example: `  # Reopen pull request #123
+  bb pr reopen 123
+
+  # Reopen a PR in a specific repository
+  bb pr reopen 123 --repo workspace/repo`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReopen(opts, args)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.repo, "repo", "R", "", "Repository in WORKSPACE/REPO format")
+
+	return cmd
+}
+
+func runReopen(opts *reopenOptions, args []string) error {
+	prNum, err := parsePRNumber(args)
+	if err != nil {
+		return err
+	}
+
+	workspace, repoSlug, err := parseRepository(opts.repo)
+	if err != nil {
+		return err
+	}
+
+	client, err := getAPIClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// First, check if PR is declined
+	pr, err := getPullRequest(ctx, client, workspace, repoSlug, prNum)
+	if err != nil {
+		return fmt.Errorf("failed to get pull request: %w", err)
+	}
+
+	if pr.State != "DECLINED" {
+		return fmt.Errorf("pull request #%d is not declined (current state: %s)", prNum, pr.State)
+	}
+
+	// Reopen the PR by updating its state to OPEN
+	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%d", workspace, repoSlug, prNum)
+	body := map[string]interface{}{
+		"state": "OPEN",
+	}
+	if _, err := client.Put(ctx, path, body); err != nil {
+		return fmt.Errorf("failed to reopen pull request: %w", err)
+	}
+
+	opts.streams.Success("Reopened pull request #%d", prNum)
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements additional PR commands (#13).

### New Commands

**`bb pr reopen <number>`**
- Reopens a declined pull request
- Validates PR is in DECLINED state before attempting reopen
- Example: `bb pr reopen 123`

**`bb pr edit <number>`**
- Edit PR title, description, or destination branch
- Flags: `--title/-t`, `--body/-b`, `--base`
- Example: `bb pr edit 123 --title "New title" --body "New description"`

**`bb pr checks <number>`**
- View CI/CD status checks for a pull request
- Shows pass/fail/running/stopped status with color-coded indicators
- Table output with STATUS, NAME, DESCRIPTION columns
- Example: `bb pr checks 123`

### API Additions
- `ReopenPullRequest(ctx, workspace, repo, prID)` - Changes PR state from DECLINED to OPEN

### All commands support
- `--repo/-R` flag for workspace/repo specification
- `--json` flag for machine-readable output

Closes #13