### PR TITLE
fix: Makefile module path + remove dead code from final review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS := -ldflags "-X github.com/rbansal42/bb/internal/cmd.Version=$(VERSION) -X github.com/rbansal42/bb/internal/cmd.BuildDate=$(BUILD_DATE)"
+LDFLAGS := -ldflags "-X github.com/rbansal42/bitbucket-cli/internal/cmd.Version=$(VERSION) -X github.com/rbansal42/bitbucket-cli/internal/cmd.BuildDate=$(BUILD_DATE)"
 
 build:
 	go build $(LDFLAGS) -o bin/bb ./cmd/bb

--- a/internal/cmd/pipeline/view.go
+++ b/internal/cmd/pipeline/view.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -299,12 +298,4 @@ func capitalize(s string) string {
 		return s
 	}
 	return string(s[0]-32) + s[1:]
-}
-
-// formatTimestamp formats a time as a readable timestamp
-func formatTimestamp(t time.Time) string {
-	if t.IsZero() {
-		return "-"
-	}
-	return t.Format("Jan 2, 2006 15:04:05")
 }


### PR DESCRIPTION
## Summary
- Fix pre-existing bug: Makefile ldflags used wrong module path (`rbansal42/bb` -> `rbansal42/bitbucket-cli`), so `make build` never injected version info
- Remove dead `formatTimestamp` function from `pipeline/view.go` (left over after timeAgo migration)
- Clean up unused `time` import

Found during 5-agent final codebase review.