### PR TITLE
Merge dev to main: completion follow-up fixes (v0.3.1)

### DIFF
--- a/internal/cmd/browse/browse.go
+++ b/internal/cmd/browse/browse.go
@@ -145,6 +145,7 @@ Use flags to open specific sections like issues, pull requests, or settings.`,
 	cmd.Flags().BoolVar(&downloads, "downloads", false, "Open downloads page")
 
 	_ = cmd.RegisterFlagCompletionFunc("repo", cmdutil.CompleteRepoNames)
+	_ = cmd.RegisterFlagCompletionFunc("branch", cmdutil.CompleteBranchNames)
 
 	return cmd
 }

--- a/internal/cmd/issue/list.go
+++ b/internal/cmd/issue/list.go
@@ -74,6 +74,10 @@ priority, or assignee.`,
 	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output in JSON format")
 	cmd.Flags().StringVar(&opts.Repo, "repo", "", "Repository in WORKSPACE/REPO format")
 
+	// NOTE: "on hold" contains a space, which is the canonical Bitbucket API value
+	// (confirmed in the OpenAPI spec enum). Cobra handles quoting automatically for
+	// zsh, fish, and PowerShell. Bash completion may require the user to quote the
+	// value (e.g. --state "on hold" or --state 'on hold').
 	_ = cmd.RegisterFlagCompletionFunc("state", cmdutil.StaticFlagCompletion([]string{
 		"new", "open", "resolved", "on hold", "invalid", "duplicate", "wontfix", "closed",
 	}))

--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -65,6 +65,10 @@ by pipeline status (PENDING, IN_PROGRESS, COMPLETED, FAILED, etc.).`,
 	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output in JSON format")
 	cmd.Flags().StringVarP(&opts.Repo, "repo", "R", "", "Repository in WORKSPACE/REPO format")
 
+	_ = cmd.RegisterFlagCompletionFunc("status", cmdutil.StaticFlagCompletion([]string{
+		"PENDING", "IN_PROGRESS", "COMPLETED", "FAILED", "STOPPED", "EXPIRED", "SUCCESSFUL",
+	}))
+	_ = cmd.RegisterFlagCompletionFunc("branch", cmdutil.CompleteBranchNames)
 	_ = cmd.RegisterFlagCompletionFunc("repo", cmdutil.CompleteRepoNames)
 
 	return cmd

--- a/internal/cmd/repo/clone.go
+++ b/internal/cmd/repo/clone.go
@@ -69,6 +69,8 @@ to change this preference.`,
 	cmd.Flags().IntVar(&opts.depth, "depth", 0, "Create a shallow clone with a limited number of commits")
 	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Clone a specific branch")
 
+	cmd.ValidArgsFunction = cmdutil.CompleteRepoNames
+
 	return cmd
 }
 
@@ -208,5 +210,3 @@ func extractRepoNameFromURL(url string) string {
 	}
 	return ""
 }
-
-

--- a/internal/cmd/repo/delete.go
+++ b/internal/cmd/repo/delete.go
@@ -49,6 +49,8 @@ unless the --yes flag is provided.`,
 
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 
+	cmd.ValidArgsFunction = cmdutil.CompleteRepoNames
+
 	return cmd
 }
 

--- a/internal/cmd/repo/fork.go
+++ b/internal/cmd/repo/fork.go
@@ -75,6 +75,7 @@ as a new remote (default name: "fork").`,
 	cmd.Flags().BoolVarP(&opts.clone, "clone", "c", false, "Clone the fork after creation")
 	cmd.Flags().StringVar(&opts.remoteName, "remote-name", "fork", "Name for the new remote when in an existing clone")
 
+	cmd.ValidArgsFunction = cmdutil.CompleteRepoNames
 	_ = cmd.RegisterFlagCompletionFunc("workspace", cmdutil.CompleteWorkspaceNames)
 
 	return cmd

--- a/internal/cmd/repo/setdefault.go
+++ b/internal/cmd/repo/setdefault.go
@@ -71,6 +71,8 @@ require a repository context.`,
 	cmd.Flags().BoolVar(&opts.View, "view", false, "Show the current default repository")
 	cmd.Flags().BoolVar(&opts.Unset, "unset", false, "Remove the default repository")
 
+	cmd.ValidArgsFunction = cmdutil.CompleteRepoNames
+
 	return cmd
 }
 

--- a/internal/cmd/repo/sync.go
+++ b/internal/cmd/repo/sync.go
@@ -57,6 +57,8 @@ By default, the main branch is synced. Use --branch to specify a different branc
 	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Branch to sync (default: main branch)")
 	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Force update (reset to upstream, discarding local changes)")
 
+	_ = cmd.RegisterFlagCompletionFunc("branch", cmdutil.CompleteBranchNames)
+
 	return cmd
 }
 

--- a/internal/cmd/repo/view.go
+++ b/internal/cmd/repo/view.go
@@ -63,6 +63,8 @@ You can specify a repository using the workspace/repo format.`,
 	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open the repository in a web browser")
 	cmd.Flags().BoolVar(&opts.jsonOut, "json", false, "Output in JSON format")
 
+	cmd.ValidArgsFunction = cmdutil.CompleteRepoNames
+
 	return cmd
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rbansal42/bitbucket-cli/internal/cmd/repo"
 	"github.com/rbansal42/bitbucket-cli/internal/cmd/snippet"
 	"github.com/rbansal42/bitbucket-cli/internal/cmd/workspace"
+	"github.com/rbansal42/bitbucket-cli/internal/cmdutil"
 	"github.com/rbansal42/bitbucket-cli/internal/iostreams"
 )
 
@@ -66,6 +67,9 @@ func Execute() error {
 func init() {
 	// Global flags
 	rootCmd.PersistentFlags().StringP("repo", "R", "", "Select a repository using the WORKSPACE/REPO format")
+	// Register completion for the persistent --repo flag. Subcommands that define
+	// their own local --repo flag will shadow this with their own registration.
+	_ = rootCmd.RegisterFlagCompletionFunc("repo", cmdutil.CompleteRepoNames)
 
 	// Version command
 	rootCmd.AddCommand(&cobra.Command{

--- a/internal/cmd/snippet/list.go
+++ b/internal/cmd/snippet/list.go
@@ -58,6 +58,9 @@ Snippets are workspace-scoped and can be filtered by your role.`,
 	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output in JSON format")
 
 	_ = cmd.RegisterFlagCompletionFunc("workspace", cmdutil.CompleteWorkspaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("role", cmdutil.StaticFlagCompletion([]string{
+		"owner", "contributor", "member",
+	}))
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Merges completion follow-up fixes from dev to main for release v0.3.1.

- Fix filterPrefix doc comment (#35)
- Extract magic numbers into named constants (#36)
- Add Username to member completion fallback chain (#37)
- Add --branch completion to browse command (#38)
- Document "on hold" space issue (#39)
- Add completions for repo/pipeline/snippet/root commands (#41)
- Fix pipeline status completion values to match API
- Remove misleading --branch completion from repo clone
- Add clarifying comment on root --repo persistent flag

## Testing

- `go build ./...` passes
- `go test ./...` all tests pass
- `go vet ./...` clean
- Shell completion generation works (bash, zsh, fish)
- 5-agent integration review: clean across all dimensions