### PR TITLE
fix: workspace list --role completion and pipeline status alignment (#44, #45)

### DIFF
--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -35,7 +35,7 @@ func NewCmdList(streams *iostreams.IOStreams) *cobra.Command {
 		Long: `List pipelines in a Bitbucket repository.
 
 By default, this shows the most recent pipelines. Use the --status flag to filter
-by pipeline status (PENDING, IN_PROGRESS, COMPLETED, FAILED, etc.).`,
+by pipeline status (PENDING, IN_PROGRESS, COMPLETED, SUCCESSFUL, FAILED, STOPPED, EXPIRED).`,
 		Example: `  # List recent pipelines
   bb pipeline list
 

--- a/internal/cmd/workspace/list.go
+++ b/internal/cmd/workspace/list.go
@@ -54,6 +54,10 @@ You can filter by your role in the workspace (owner, collaborator, or member).`,
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "l", 30, "Maximum number of workspaces to list")
 	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output in JSON format")
 
+	_ = cmd.RegisterFlagCompletionFunc("role", cmdutil.StaticFlagCompletion([]string{
+		"owner", "collaborator", "member",
+	}))
+
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

- **#44**: Add `--role` static completion for `workspace list` command (`owner`, `collaborator`, `member`)
- **#45**: Align pipeline list long description to list all valid status values instead of `etc.`

2 files changed, 5 insertions, 1 deletion. Trivial fixes.